### PR TITLE
Optional custom next button via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ AppRegistry.registerComponent('myproject', () => Swiper);
 | buttonWrapperStyle | `{backgroundColor: 'transparent', flexDirection: 'row', position: 'absolute', top: 0, left: 0, flex: 1, paddingHorizontal: 10, paddingVertical: 10, justifyContent: 'space-between', alignItems: 'center'}` | `style` | Custom styles. |
 | nextButton | `<Text style={styles.buttonText}>›</Text>` | `element` | Allow custom the next button. |
 | prevButton | `<Text style={styles.buttonText}>‹</Text>` | `element` | Allow custom the prev button. |
+| disableNextButton | false | `bool` | Optionally disable next control button. |
+| nextBtnLastSlide | `<NavButton onPress={customFn() => { doRouting(); }/>` | `element` | Allow custom next button, even on last slide if looping is set to false |
 
 #### Props of Children
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ export default class extends Component {
     activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string,
+    nextBtnLastSlide: PropTypes.node,
     /**
      * Called when the index has changed because the user swiped.
      */
@@ -615,6 +616,16 @@ export default class extends Component {
     )
   }
 
+  renderOwnNextButton = (element) => {
+    const button = element ? element : null;
+
+    return (
+      <View>
+        {button}
+      </View>
+    );
+  }
+
   refScrollView = view => {
     this.scrollView = view;
   }
@@ -722,6 +733,7 @@ export default class extends Component {
           : this.renderPagination())}
         {this.renderTitle()}
         {showsButtons && this.renderButtons()}
+        {this.renderOwnNextButton(this.props.nextBtnLastSlide)}
       </View>
     )
   }


### PR DESCRIPTION
### Is it a bugfix ?
- No

### Is it a new feature ?
- Yes
- Added documentation to readme
  * https://www.dropbox.com/s/xmi2lx8o67mg6vx/Screenshot%202018-04-09%2012.01.36.png?dl=0
    * Here we render an element on top of the control button wrapper using the new prop

### Describe what you've done:
- Optionally supply a completely custom element to the swiper, which will render on top of all other swiper elements. This could be used in many ways when you want to render something above swiper content, especially the control button wrapper. See the image above for an example of rendering a custom navigation button where the usual one would be, in the control button wrapper, except this is on the last slide in a swiper where `looping={false}`, so you would normally not get a button here.

### How to test it ?
- Try setting `showsButtons={false}`, then set 

`nextBtnLastSlide={<TouchableOpacity onPress={() => { console.log( 'Hello world!'); } }><View style={{ bottom: 0, right: 0, height: 50, width: 50, backgroundColor: 'green' }} /> />}`

- Now look to see your shiny, new, green button that should console.log 'Hello world!'.
